### PR TITLE
Add version export

### DIFF
--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -2,7 +2,7 @@
 Intelligent builder for working with component-based repositories
 
 Usage:
-  compbuild discover [--all]
+  compbuild discover [--all] [--with-versions]
   compbuild build [<component>...] [--all]
   compbuild env [<component>...] [--all]
   compbuild release [<component>...] [--all]
@@ -16,6 +16,8 @@ Options:
   -h --help            Show this screen.
   --all                Do all the components
   --version            Show version.
+  --with-versions      Print out all items of interest, with associated versions
+
 """
 import json
 
@@ -38,7 +40,11 @@ def cli():
     envs.set_envs(components)
 
     if arguments['discover']:
-        print("\n".join(c.title for c in components))
+        tmpl = "{title}"
+        if arguments['--with-versions']:
+            tmpl += ':{version}'
+        for c in components:
+            print(tmpl.format(title=c.title, version=c.env['VERSION']))
     elif arguments['build']:
         build.run('build', components)
     elif arguments['test']:

--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -2,13 +2,13 @@
 Intelligent builder for working with component-based repositories
 
 Usage:
-  compbuild discover [--all] [--with-versions]
-  compbuild build [<component>...] [--all]
-  compbuild env [<component>...] [--all]
-  compbuild release [<component>...] [--all]
-  compbuild test [<component>...] [--all]
-  compbuild tag [<component>...] [--all]
-  compbuild label <label> [<component>...] [--all]
+  compbuild discover [--all] [--with-versions] [--conf=FILE]
+  compbuild build [<component>...] [--all] [--conf=FILE]
+  compbuild env [<component>...] [--all] [--conf=FILE]
+  compbuild release [<component>...] [--all] [--conf=FILE]
+  compbuild test [<component>...] [--all] [--conf=FILE]
+  compbuild tag [<component>...] [--all] [--conf=FILE]
+  compbuild label <label> [<component>...] [--all] [--conf=FILE]
   compbuild -h | --help
   compbuild --version
 
@@ -16,20 +16,22 @@ Options:
   -h --help            Show this screen.
   --all                Do all the components
   --version            Show version.
+  --conf=FILE          Configuration file location [default: builder.ini]
   --with-versions      Print out all items of interest, with associated versions
 
 """
 import json
+import sys
 
 from docopt import docopt
 
 from . import build, discover, envs, github, release
 
 
-def cli():
+def cli(out=sys.stdout):
     arguments = docopt(__doc__, version='1.0')
 
-    b = build.Builder()
+    b = build.Builder(arguments['--conf'])
     b.configure()
 
     components = discover.run(
@@ -44,7 +46,9 @@ def cli():
         if arguments['--with-versions']:
             tmpl += ':{version}'
         for c in components:
-            print(tmpl.format(title=c.title, version=c.env['VERSION']))
+            out.write(
+                tmpl.format(title=c.title, version=c.env['VERSION']) + '\n'
+            )
     elif arguments['build']:
         build.run('build', components)
     elif arguments['test']:
@@ -60,7 +64,7 @@ def cli():
     elif arguments['release']:
         release.run(components)
     elif arguments['env']:
-        print("\n".join(json.dumps(c.env, indent=4) for c in components))
+        out.write("\n".join(json.dumps(c.env, indent=4) for c in components))
 
 if __name__ == '__main__':
     cli()

--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -17,7 +17,7 @@ Options:
   --all                Do all the components
   --version            Show version.
   --conf=FILE          Configuration file location [default: builder.ini]
-  --with-versions      Print out all items of interest, with associated versions
+  --with-versions      Print out all items of interest, with versions
 
 """
 import json
@@ -42,9 +42,9 @@ def cli(out=sys.stdout):
     envs.set_envs(components)
 
     if arguments['discover']:
-        tmpl = "{title}"
+        tmpl = u"{title}"
         if arguments['--with-versions']:
-            tmpl += ':{version}'
+            tmpl += u':{version}'
         for c in components:
             out.write(
                 tmpl.format(title=c.title, version=c.env['VERSION']) + '\n'

--- a/component-builder/src/component_builder/build.py
+++ b/component-builder/src/component_builder/build.py
@@ -48,7 +48,6 @@ class Builder(object):
     def __init__(self, builder_file):
         self.builder_file = builder_file
         self.path = os.path.dirname(self.builder_file)
-        self.components = {}
 
     def configure(self):
         self.components = config.read_component_configuration(

--- a/component-builder/src/component_builder/build.py
+++ b/component-builder/src/component_builder/build.py
@@ -45,14 +45,14 @@ def command_exists(component, command):
 
 
 class Builder(object):
-    def __init__(self, root_dir='.'):
-        self.path = os.path.abspath(root_dir)
+    def __init__(self, builder_file):
+        self.builder_file = builder_file
+        self.path = os.path.dirname(self.builder_file)
         self.components = {}
 
     def configure(self):
         self.components = config.read_component_configuration(
-            open(os.path.join(self.path, 'builder.ini')),
-            root=self.path
+            open(self.builder_file), root=self.path
         )
         return self.components
 

--- a/component-builder/src/component_builder/config.py
+++ b/component-builder/src/component_builder/config.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import os.path
 try:
     from configparser import ConfigParser
@@ -13,7 +14,7 @@ def read_component_configuration(builder_ini_file, root='.'):
         'release-process': ''
     })
     config.readfp(builder_ini_file)
-    components = {}
+    components = OrderedDict()
     for component in config.sections():
         kwargs = {
             'title': component,

--- a/component-builder/tests/test_cli.py
+++ b/component-builder/tests/test_cli.py
@@ -1,7 +1,7 @@
-from StringIO import StringIO
-import unittest
+from io import StringIO
 import os
 from os.path import abspath, dirname, join
+import unittest
 
 from mock import patch
 

--- a/component-builder/tests/test_cli.py
+++ b/component-builder/tests/test_cli.py
@@ -1,0 +1,50 @@
+from StringIO import StringIO
+import unittest
+import os
+from os.path import abspath, dirname, join
+
+from mock import patch
+
+from component_builder.__main__ import cli
+
+TEST_BUILDER_CONF = abspath(
+    join(dirname(__file__), 'dummy-single-repo', 'builder.ini')
+)
+
+
+@patch('component_builder.build.os.environ', {
+    'BUILD_IDENTIFIER': '1'
+})
+class TestCli(unittest.TestCase):
+
+    @patch('sys.argv', ['compbuild', 'discover', '--all', '--with-versions',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    def test_discover_with_versions(self):
+        s = StringIO()
+        cli(out=s)
+
+        self.assertEqual(
+            s.getvalue(),
+            '\n'.join([
+                'dummy-app:5.4.1',
+                'dummy-integration:2.0.1',
+                'dummy-island-service:1.5.1',
+                ''
+            ])
+        )
+
+    @patch('sys.argv', ['compbuild', 'discover', '--all',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    def test_discover_without_versions(self):
+        s = StringIO()
+        cli(out=s)
+
+        self.assertEqual(
+            s.getvalue(),
+            '\n'.join([
+                'dummy-app',
+                'dummy-integration',
+                'dummy-island-service',
+                ''
+            ])
+        )

--- a/component-builder/tests/test_envs.py
+++ b/component-builder/tests/test_envs.py
@@ -19,8 +19,8 @@ from component_builder.envs import set_envs
 class TestSetEnvs(unittest.TestCase):
 
     def setUp(self):
-        appdir = join(dirname(__file__), 'dummy-single-repo')
-        b = Builder(appdir)
+        conf = join(dirname(__file__), 'dummy-single-repo', 'builder.ini')
+        b = Builder(conf)
         self.components = b.configure()
         self.ordered_candidates = Tree.ordered(self.components.values())
 


### PR DESCRIPTION
`discover` to optionally export versions to be built too.

Useful if you're wanting to run deployments of built versions.
