### PR TITLE
Add docker-tox image for building things

### DIFF
--- a/builder.ini
+++ b/builder.ini
@@ -1,3 +1,7 @@
 [builder]
 path=component-builder
 release-process=custom
+
+[docker-tox]
+path=docker-tox
+release-process=docker

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,9 @@ machine:
     PULL_REQUEST_NAMES: $CI_PULL_REQUESTS
     INTERACT_WITH_GITHUB: yes
 
+  services:
+    - docker
+
 dependencies:
   override:
     - cd component-builder && echo "0.0" > VERSION.txt && pip install -e .

--- a/docker-tox/Dockerfile
+++ b/docker-tox/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:latest
+
+RUN apk --update add bash curl ca-certificates git build-base \
+    libffi-dev openssl-dev libbz2 libc6-compat ncurses-dev readline-dev \
+    xz-dev zlib-dev sqlite-dev patch bzip2-dev expat-dev zlib-dev \
+    gdbm-dev paxmark linux-headers tcl-dev
+
+COPY setup.sh /setup.sh
+
+RUN /bin/bash /setup.sh \
+    && rm /setup.sh
+
+ENV HOME /root
+ENV PYENV_ROOT $HOME/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH

--- a/docker-tox/Makefile
+++ b/docker-tox/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build test release version
+
+build:
+	docker build -t docker-tox:${VERSION} .
+
+test:
+	echo "Nothing to test"
+
+version:
+	echo "1.0.${BUILD_NUMBER}"

--- a/docker-tox/setup.sh
+++ b/docker-tox/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+PYTHON_VERSIONS=(2.7.10 3.5.2)
+PYTHON_GLOBAL_VERSION=2.7.10
+PYTHON_PIP_VERSION=7.1.2
+
+# Install pyenv
+curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer -o /pyenv-installer
+touch /root/.bashrc
+/bin/ln -s /root/.bashrc /root/.bash_profile
+/bin/bash /pyenv-installer
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bash_profile
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+
+# Install all python versions
+for v in "${PYTHON_VERSIONS[@]}"; do
+    pyenv install $v &
+done
+wait
+
+# Set global python version
+pyenv global $PYTHON_GLOBAL_VERSION "${PYTHON_VERSIONS[@]}"
+
+# Install tox
+pip install -U pip
+pip install -U tox
+
+# Cleanup
+rm /pyenv-installer
+rm -rf /var/cache/apk/*
+rm -rf /tmp/python*
+rm -rf /tmp/pip*


### PR DESCRIPTION
A useful image that will end up in docker hub that means in jenkins users can easily create containers that inherit from this one and have tox and multiple python versions available.

Very debatable as to whether this should live elsewhere.