### PR TITLE
Add a non-empty default location for reports

### DIFF
--- a/component-builder/tox.ini
+++ b/component-builder/tox.ini
@@ -4,4 +4,4 @@ envlist = py27,py35
 [testenv]
 passenv = *
 deps=-rrequirements/test.txt
-commands=nosetests --with-xunit --xunit-file={env:REPORT_LOCATION:}/nosetests.xml -s .
+commands=nosetests --with-xunit --xunit-file={env:REPORT_LOCATION:.reports}/nosetests.xml -s .


### PR DESCRIPTION
An empty default report location is not very helpful. If not provided, it will try to write reports to `/nosetests.xml` and fail due to lack of permissions.