### PR TITLE
Add --filter option to select components

### DIFF
--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -2,7 +2,8 @@
 Intelligent builder for working with component-based repositories
 
 Usage:
-  compbuild discover [--all] [--with-versions] [--conf=FILE]
+  compbuild discover [--all] [--filter=SELECTOR] [--with-versions] \
+[--conf=FILE]
   compbuild build [<component>...] [--all] [--conf=FILE]
   compbuild env [<component>...] [--all] [--conf=FILE]
   compbuild release [<component>...] [--all] [--conf=FILE]
@@ -15,6 +16,8 @@ Usage:
 Options:
   -h --help            Show this screen.
   --all                Do all the components
+  --filter=SELECTOR    Filter components based on selector
+                       (e.g. --filter=relase-process=docker)
   --version            Show version.
   --conf=FILE          Configuration file location [default: builder.ini]
   --with-versions      Print out all items of interest, with versions
@@ -34,10 +37,15 @@ def cli(out=sys.stdout):
     b = build.Builder(arguments['--conf'])
     b.configure()
 
+    selectors = arguments['--filter']
+    if selectors:
+        selectors = selectors.split(',')
+
     components = discover.run(
         b.components,
         arguments.get('<component>', []),
-        arguments['--all']
+        arguments['--all'],
+        selectors,
     )
     envs.set_envs(components)
 

--- a/component-builder/src/component_builder/component.py
+++ b/component-builder/src/component_builder/component.py
@@ -5,7 +5,8 @@ class Component(object):
 
     all = {}
 
-    def __init__(self, title, path, release_process='', upstream=None):
+    def __init__(self, title, path, release_process='', upstream=None,
+                 ini=None):
         """
         title: Name of the component. Used for docker images and more...
         path: Path to the component (within which a makefile will be found)
@@ -20,6 +21,7 @@ class Component(object):
         self.env = {}
         self.all[title] = self
         self.path = path
+        self.ini = ini
 
     def branch_name(self, label='stable'):
         return "{0}-{1}".format(label, self.title)

--- a/component-builder/src/component_builder/config.py
+++ b/component-builder/src/component_builder/config.py
@@ -16,10 +16,13 @@ def read_component_configuration(builder_ini_file, root='.'):
     config.readfp(builder_ini_file)
     components = OrderedDict()
     for component in config.sections():
+        ini_section_dict = dict(config.items(component))
+
         kwargs = {
             'title': component,
             'release_process': config.get(component, 'release-process'),
-            'path': os.path.join(root, config.get(component, 'path'))
+            'path': os.path.join(root, config.get(component, 'path')),
+            'ini': ini_section_dict,
         }
         upstream = config.get(component, 'upstream')
         if upstream:

--- a/component-builder/src/component_builder/discover.py
+++ b/component-builder/src/component_builder/discover.py
@@ -29,7 +29,8 @@ def filter_by(selectors, components):
 def run(components, component_names=None, get_all=False, selectors=None):
     "Get paths and titles of changed components"
     if component_names and get_all:
-        print("Asked to filter and get all. Assuming filter...")
+        print("Asked for specific components and get all. "
+              "Assuming specific components...")
     if component_names:
         candidates = [components[x] for x in component_names]
     else:

--- a/component-builder/tests/dummy-single-repo/builder.ini
+++ b/component-builder/tests/dummy-single-repo/builder.ini
@@ -1,9 +1,13 @@
 [dummy-app]
 path=dummy-app
+release-process=docker
+label=app
 
 [dummy-integration]
 path=dummy-integration
 upstream=dummy-app
+label=app
 
 [dummy-island-service]
 path=dummy-island-service
+release-process=docker

--- a/component-builder/tests/test_cli.py
+++ b/component-builder/tests/test_cli.py
@@ -1,5 +1,4 @@
 from io import StringIO
-import os
 from os.path import abspath, dirname, join
 import unittest
 
@@ -45,6 +44,37 @@ class TestCli(unittest.TestCase):
                 'dummy-app',
                 'dummy-integration',
                 'dummy-island-service',
+                ''
+            ])
+        )
+
+    @patch('sys.argv', ['compbuild', 'discover', '--all',
+                        '--filter=release-process=docker',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    def test_discover_filter_by_one_key(self):
+        s = StringIO()
+        cli(out=s)
+
+        self.assertEqual(
+            s.getvalue(),
+            '\n'.join([
+                'dummy-app',
+                'dummy-island-service',
+                ''
+            ])
+        )
+
+    @patch('sys.argv', ['compbuild', 'discover', '--all',
+                        '--filter=release-process=docker,label=app',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    def test_discover_filter_by_multiple_keys(self):
+        s = StringIO()
+        cli(out=s)
+
+        self.assertEqual(
+            s.getvalue(),
+            '\n'.join([
+                'dummy-app',
                 ''
             ])
         )

--- a/component-builder/tests/test_envs.py
+++ b/component-builder/tests/test_envs.py
@@ -1,14 +1,11 @@
 import os
 from os.path import join, dirname
-# import shutil
-# import tempfile
 import unittest
 
 from mock import patch
 
-from component_builder import config
 from component_builder.build import Builder
-from component_builder.component import Component, Tree
+from component_builder.component import Tree
 from component_builder.envs import set_envs
 
 
@@ -28,7 +25,7 @@ class TestSetEnvs(unittest.TestCase):
         set_envs(self.ordered_candidates)
 
         self.assertEqual(
-            sorted(self.components['dummy-island-service'].env_string.split(' ')),
+            sorted(self.components['dummy-island-service'].env_string.split()),
             ['DOCKER_IMAGE=dummy-island-service', 'DOCKER_TAG=1.5.0.1',
              'REPORT_LOCATION=/reports/dummy-island-service',
              'VERSION=1.5.0.1']
@@ -38,7 +35,7 @@ class TestSetEnvs(unittest.TestCase):
         set_envs(self.ordered_candidates)
 
         self.assertEqual(
-            sorted(self.components['dummy-integration'].env_string.split(' ')),
+            sorted(self.components['dummy-integration'].env_string.split()),
             ['DOCKER_IMAGE=dummy-integration',
              'DOCKER_TAG=2.0.0.1',
              'DUMMY_APP_DOCKER_IMAGE=dummy-app:5.4.0.1',
@@ -51,7 +48,7 @@ class TestSetEnvs(unittest.TestCase):
 
         set_envs(self.ordered_candidates)
         self.assertEqual(
-            sorted(self.components['dummy-app'].env_string.split(' ')),
+            sorted(self.components['dummy-app'].env_string.split()),
             ['ANOTHER_VAR=$CIRCLE_MAGIC', 'DOCKER_IMAGE=dummy-app',
              'DOCKER_TAG=5.4.0.1', 'REPORT_LOCATION=/reports/dummy-app',
              'VERSION=5.4.0.1']


### PR DESCRIPTION
Allows filtering based on any matching `key=value` in the component's `builder.ini` section.