### PR TITLE
Ensure all commands use the same common flags

### DIFF
--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -1,15 +1,22 @@
-"""
+import json
+import sys
+
+from docopt import docopt
+
+from . import build, discover, envs, github, release
+
+
+USAGE = """
 Intelligent builder for working with component-based repositories
 
 Usage:
-  compbuild discover [--all] [--filter=SELECTOR] [--with-versions] \
-[--conf=FILE]
-  compbuild build [<component>...] [--all] [--conf=FILE]
-  compbuild env [<component>...] [--all] [--conf=FILE]
-  compbuild release [<component>...] [--all] [--conf=FILE]
-  compbuild test [<component>...] [--all] [--conf=FILE]
-  compbuild tag [<component>...] [--all] [--conf=FILE]
-  compbuild label <label> [<component>...] [--all] [--conf=FILE]
+  compbuild discover [--with-versions] {common}
+  compbuild build [<component>...] {common}
+  compbuild env [<component>...] {common}
+  compbuild release [<component>...] {common}
+  compbuild test [<component>...] {common}
+  compbuild tag [<component>...] {common}
+  compbuild label <label> [<component>...] {common}
   compbuild -h | --help
   compbuild --version
 
@@ -22,17 +29,13 @@ Options:
   --conf=FILE          Configuration file location [default: builder.ini]
   --with-versions      Print out all items of interest, with versions
 
-"""
-import json
-import sys
-
-from docopt import docopt
-
-from . import build, discover, envs, github, release
+""".format(
+    common='[--all] [--filter=SELECTOR] [--conf=FILE]'
+)
 
 
 def cli(out=sys.stdout):
-    arguments = docopt(__doc__, version='1.0')
+    arguments = docopt(USAGE, version='1.0')
 
     b = build.Builder(arguments['--conf'])
     b.configure()

--- a/component-builder/tests/dummy-single-repo/dummy-app/Makefile
+++ b/component-builder/tests/dummy-single-repo/dummy-app/Makefile
@@ -1,2 +1,5 @@
+build:
+	echo "Building dummy app"
+
 version:
 	echo "5.4.${BUILD_IDENTIFIER}"

--- a/component-builder/tests/dummy-single-repo/dummy-integration/Makefile
+++ b/component-builder/tests/dummy-single-repo/dummy-integration/Makefile
@@ -1,2 +1,5 @@
+build:
+	echo "Building dummy integration"
+
 version:
 	echo "2.0.${BUILD_IDENTIFIER}"

--- a/component-builder/tests/dummy-single-repo/dummy-island-service/Makefile
+++ b/component-builder/tests/dummy-single-repo/dummy-island-service/Makefile
@@ -1,2 +1,5 @@
+build:
+	echo "Building dummy island service"
+
 version:
 	echo "1.5.${BUILD_IDENTIFIER}"


### PR DESCRIPTION
`build` and others could not be used with the new flags because the docopt usage string did not include them. This adds them in a DRYer way.