### PR TITLE
Add compare to master flag

### DIFF
--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -10,7 +10,7 @@ USAGE = """
 Intelligent builder for working with component-based repositories
 
 Usage:
-  compbuild discover [--with-versions] {common}
+  compbuild discover [--with-versions] [--vs-branch=BRANCH]{common}
   compbuild build [<component>...] {common}
   compbuild env [<component>...] {common}
   compbuild release [<component>...] {common}
@@ -29,6 +29,9 @@ Options:
   --version            Show version.
   --conf=FILE          Configuration file location [default: builder.ini]
   --with-versions      Print out all items of interest, with versions
+  --vs-branch=BRANCH   Discover changes made compared to BRANCH. If not set,
+                       comparison will be to latest staging branch for each
+                       component.
 
 """.format(
     common='[--all] [--filter=SELECTOR] [--conf=FILE]'
@@ -49,7 +52,8 @@ def cli(out=sys.stdout):
         b.components,
         arguments.get('<component>', []),
         arguments['--all'],
-        selectors,
+        compare_branch=arguments['--vs-branch'],
+        selectors=selectors,
     )
     envs.set_envs(components)
 

--- a/component-builder/src/component_builder/config.py
+++ b/component-builder/src/component_builder/config.py
@@ -15,7 +15,7 @@ def read_configuration(builder_ini_file, root='.'):
     })
     config.readfp(builder_ini_file)
     component_config = OrderedDict()
-    builder_config = {}
+    builder_config = {'custom_scripts': {}}
 
     for component in config.sections():
         ini_section_dict = dict(config.items(component))

--- a/component-builder/src/component_builder/discover.py
+++ b/component-builder/src/component_builder/discover.py
@@ -26,7 +26,8 @@ def filter_by(selectors, components):
     return list(components)
 
 
-def run(components, component_names=None, get_all=False, selectors=None):
+def run(components, component_names=None, get_all=False, compare_branch=None,
+        selectors=None):
     "Get paths and titles of changed components"
     if component_names and get_all:
         print("Asked for specific components and get all. "
@@ -36,7 +37,7 @@ def run(components, component_names=None, get_all=False, selectors=None):
     else:
         candidates = components.values()
         if not get_all:
-            candidates = get_changed(candidates)
+            candidates = get_changed(candidates, compare_branch)
         candidates = Tree.ordered(candidates)
 
     if selectors:


### PR DESCRIPTION
This allows non master builds to use:

`compbuild discover --vs-branch=master` 

to only build things changed since master. Right now, they'll build anything changed compared to the *latest stable version* of their branch. If master has just been merged and triggered a run on any open PRs, this means that many more things are built than need to be (since master itself hasn't run yet and been merged into appropriate stable branches)