### PR TITLE
Include locally uncommitted changes as things that should be built

### DIFF
--- a/component-builder/src/component_builder/discover.py
+++ b/component-builder/src/component_builder/discover.py
@@ -7,9 +7,9 @@ def get_changed(candidates, branch=None):
 
     def is_changed(candidate):
         name = branch or candidate.branch_name('stable')
-
-        b = bash('git log --oneline origin/{branch}..HEAD '
-                 '-- {0} || echo "1"'.format(candidate.path, branch=name))
+        cmd = ('git diff --shortstat origin/{branch} '
+               '-- {0} || echo "1"'.format(candidate.path, branch=name))
+        b = bash(cmd)
         return b.value().strip() != ''
     return filter(is_changed, candidates)
 


### PR DESCRIPTION
The use of `git diff` rather than `git log` means that local changes to a component will be considered worthy of a build/test of that component when run with `compbuild build` or `compbuild test`

Without this, changes must be committed in order to be reflected in any built docker images for example