### PR TITLE
support multiple --filter arguments

### DIFF
--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -10,7 +10,7 @@ USAGE = """
 Intelligent builder for working with component-based repositories
 
 Usage:
-  compbuild discover [--with-versions] [--vs-branch=BRANCH]{common}
+  compbuild discover [--with-versions] [--vs-branch=BRANCH] {common}
   compbuild build [<component>...] {common}
   compbuild env [<component>...] {common}
   compbuild release [<component>...] {common}
@@ -34,7 +34,7 @@ Options:
                        component.
 
 """.format(
-    common='[--all] [--filter=SELECTOR] [--conf=FILE]'
+    common='[--all] [--filter=SELECTOR ...] [--conf=FILE]'
 )
 
 
@@ -44,9 +44,11 @@ def cli(out=sys.stdout):
     b = build.Builder(arguments['--conf'])
     b.configure()
 
-    selectors = arguments['--filter']
-    if selectors:
-        selectors = selectors.split(',')
+    selectors = set()
+    filters = arguments['--filter']
+    for fltr in filters:
+        selectors.update(fltr.split(','))
+    selectors = list(selectors)
 
     components = discover.run(
         b.components,

--- a/component-builder/tests/test_cli.py
+++ b/component-builder/tests/test_cli.py
@@ -80,6 +80,22 @@ class TestCli(unittest.TestCase):
             ])
         )
 
+    @patch('sys.argv', ['compbuild', 'discover', '--all',
+                        '--filter=release-process=docker',
+                        '--filter=label=app',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    def test_discover_filter_by_multiple_arguments(self):
+        s = StringIO()
+        cli(out=s)
+
+        self.assertEqual(
+            s.getvalue(),
+            '\n'.join([
+                'dummy-app',
+                ''
+            ])
+        )
+
     @patch('sys.argv', ['compbuild', 'build', '--all',
                         '--conf={0}'.format(TEST_BUILDER_CONF)])
     def test_custom_commands(self):
@@ -96,7 +112,7 @@ class TestCli(unittest.TestCase):
             "bar dummy-app\nbar dummy-integration\nbar dummy-island-service\n"
         )
 
-    @patch('sys.argv', ['compbuild', 'discover', '--vs-branch=master', 
+    @patch('sys.argv', ['compbuild', 'discover', '--vs-branch=master',
                         '--conf={0}'.format(TEST_BUILDER_CONF)])
     def test_discover_only_finds_changes(self):
         s = StringIO()
@@ -111,7 +127,7 @@ class TestCli(unittest.TestCase):
                         '--conf={0}'.format(TEST_BUILDER_CONF)])
     def test_discover_local_uncommitted_changes_count(self):
         def setup_changed_file():
-            local_file = join(dirname(TEST_BUILDER_CONF), 
+            local_file = join(dirname(TEST_BUILDER_CONF),
                               'dummy-island-service/Makefile')
             orig_content = open(local_file, 'r').read()
             def write_to_file(filename, content):
@@ -125,11 +141,11 @@ class TestCli(unittest.TestCase):
                 '\techo "1.5.${BUILD_IDENTIFIER}"'
             )
             write_to_file(
-                local_file, 
+                local_file,
                 test_makefile
             )
             self.addCleanup(write_to_file, local_file, orig_content)
-        
+
         setup_changed_file()
         s = StringIO()
         cli(out=s)


### PR DESCRIPTION
the following examples will all work:
  --filter=a=1,b=2
  --filter=a=1 --filter=b=2
  --filter=a=1,b=2 --filter=c=3