### PR TITLE
Remove old component labels from PRs

### DIFF
--- a/component-builder/src/component_builder/build.py
+++ b/component-builder/src/component_builder/build.py
@@ -31,12 +31,12 @@ def mark_commit_status(*args, **kwargs):
         return github.mark_status_for_component(*args, **kwargs)
 
 
-def declare_component_usage(title):
+def declare_components_usage(titles):
     if os.environ.get('INTERACT_WITH_GITHUB'):
         prs = os.environ.get('PULL_REQUEST_NAMES', '')
         for pr_url in prs.split(','):
             if pr_url:
-                github.add_pr_component_label(pr_url, title)
+                github.add_pr_components_labels(pr_url, titles)
 
 
 def command_exists(component, command):
@@ -83,9 +83,11 @@ class Builder(object):
 def run(mode, components, status_callback=None, optional=False):
     errors = []
 
+    titles = []
     for comp in components:
-        declare_component_usage(comp.title)
+        titles.append(comp.title)
         mark_commit_status(mode, comp.title, 'pending')
+    declare_components_usage(titles)
 
     for comp in components:
         comp_name = comp.title

--- a/component-builder/src/component_builder/github.py
+++ b/component-builder/src/component_builder/github.py
@@ -79,19 +79,21 @@ def validate_pr_url(pr_url):
         )
 
 
-def add_pr_component_label(pr_url, title):
-    new_label = 'component:{0}'.format(title)
+def add_pr_components_labels(pr_url, titles):
     validate_pr_url(pr_url)
     issue_id = pr_url.split('/')[-1]
     repo = get_repo()
     issue = repo.issue(issue_id)
 
-    for l in issue.labels():
-        if l.name == new_label:
+    new_labels = ['component:{0}'.format(title) for title in titles]
+    for label in issue.labels():
+        if label.name in new_labels:
             # Already added to the issue
-            return
-
-    issue.add_labels(new_label)
+            new_labels.remove(label.name)
+        else:
+            # Should not exist anymore
+            issue.remove_label(label.name)
+    issue.add_labels(new_labels)
 
 
 class ValidationError(Exception):

--- a/component-builder/src/component_builder/github.py
+++ b/component-builder/src/component_builder/github.py
@@ -86,13 +86,15 @@ def add_pr_components_labels(pr_url, titles):
     issue = repo.issue(issue_id)
 
     new_labels = ['component:{0}'.format(title) for title in titles]
-    for label in issue.labels():
-        if label.name in new_labels:
+    component_labels = [
+        l.name for l in issue.labels() if l.name.startwith('component:')]
+    for label in component_labels:
+        if label in new_labels:
             # Already added to the issue
-            new_labels.remove(label.name)
+            new_labels.remove(label)
         else:
             # Should not exist anymore
-            issue.remove_label(label.name)
+            issue.remove_label(label)
     issue.add_labels(new_labels)
 
 

--- a/component-builder/tests/test_github.py
+++ b/component-builder/tests/test_github.py
@@ -1,3 +1,4 @@
+import six
 import unittest
 
 from component_builder import github
@@ -37,5 +38,5 @@ class TestAddPRComponentsLabels(unittest.TestCase):
         to_add, to_del = github.replace_labels(
             component_titles, current_labels)
 
-        self.assertItemsEqual(to_add, ['component:library'])
-        self.assertItemsEqual(to_del, ['component:tool'])
+        six.assertCountEqual(self, to_add, ['component:library'])
+        six.assertCountEqual(self, to_del, ['component:tool'])

--- a/component-builder/tests/test_github.py
+++ b/component-builder/tests/test_github.py
@@ -17,3 +17,25 @@ class TestValidatePRURL(unittest.TestCase):
             self.assertRaises(
                 github.ValidationError, github.validate_pr_url, invalid
             )
+
+
+class Label(object):
+    def __init__(self, name):
+        self.name = name
+
+    def name(self):
+        return self.name
+
+
+class TestAddPRComponentsLabels(unittest.TestCase):
+
+    def test_replace_labels(self):
+        component_titles = ['library', 'service']
+        current_labels = [
+            Label('component:tool'), Label('component:service'),
+            Label('not-a-component')]
+        to_add, to_del = github.replace_labels(
+            component_titles, current_labels)
+
+        self.assertItemsEqual(to_add, ['component:library'])
+        self.assertItemsEqual(to_del, ['component:tool'])


### PR DESCRIPTION
This should cleanup component labels from PRs that were added on earlier commits, but should now be removed.