### PR TITLE
Add ability to exclude results

### DIFF
--- a/component-builder/src/component_builder/discover.py
+++ b/component-builder/src/component_builder/discover.py
@@ -17,8 +17,17 @@ def get_changed(candidates, branch=None):
 def filter_by(selectors, components):
 
     def matches_selector(selector, component):
-        key, value = selector.split('=')
-        return component.ini.get(key) == value
+        sep = '='
+        exclude = False
+        if '!=' in selector:
+            sep = '!='
+            exclude = True
+
+        key, value = selector.split(sep)
+        if exclude:
+            return component.ini.get(key) != value
+        else:
+            return component.ini.get(key) == value
 
     for selector in selectors:
         components = filter(partial(matches_selector, selector), components)

--- a/component-builder/tests/test_cli.py
+++ b/component-builder/tests/test_cli.py
@@ -81,6 +81,21 @@ class TestCli(unittest.TestCase):
         )
 
     @patch('sys.argv', ['compbuild', 'discover', '--all',
+                        '--filter=release-process=docker,label!=app',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    def test_discover_filter_with_excludes_multiple_keys(self):
+        s = StringIO()
+        cli(out=s)
+
+        self.assertEqual(
+            s.getvalue(),
+            '\n'.join([
+                'dummy-island-service',
+                ''
+            ])
+        )
+    
+    @patch('sys.argv', ['compbuild', 'discover', '--all',
                         '--filter=release-process=docker',
                         '--filter=label=app',
                         '--conf={0}'.format(TEST_BUILDER_CONF)])


### PR DESCRIPTION
This is useful if you want to "get all components that aren't libraries" for example.