### PR TITLE
Make 'declare components usage' (via labels) its own command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Any component defined in builder.ini will be treated as a first class citizen.
 
 ## Typical Flow
 
+    $ compbuild declare
     $ compbuild build
     $ compbuild test
     $ compbuild label 'stable'
@@ -179,20 +180,29 @@ GIT_TAGGER_EMAIL
     Intelligent builder for working with component-based repositories
 
     Usage:
-      compbuild discover [--all]
-      compbuild build [<component>...] [--all]
-      compbuild env [<component>...] [--all]
-      compbuild release [<component>...] [--all]
-      compbuild test [<component>...] [--all]
-      compbuild tag [<component>...] [--all]
-      compbuild label <label> [<component>...] [--all]
+      compbuild discover [--with-versions] [--vs-branch=BRANCH] [--all] [--filter=SELECTOR ...] [--conf=FILE]
+      compbuild declare [<component>...] [--all] [--filter=SELECTOR ...] [--conf=FILE]
+      compbuild build [<component>...] [--all] [--filter=SELECTOR ...] [--conf=FILE]
+      compbuild test [<component>...] [--all] [--filter=SELECTOR ...] [--conf=FILE]
+      compbuild label <label> [<component>...] [--all] [--filter=SELECTOR ...] [--conf=FILE]
+      compbuild tag [<component>...] [--all] [--filter=SELECTOR ...] [--conf=FILE]
+      compbuild release [<component>...] [--all] [--filter=SELECTOR ...] [--conf=FILE]
+      compbuild get <attr> [<component>...] [--all] [--filter=SELECTOR ...] [--conf=FILE]
+      compbuild env [<component>...] [--all] [--filter=SELECTOR ...] [--conf=FILE]
       compbuild -h | --help
       compbuild --version
 
     Options:
       -h --help            Show this screen.
       --all                Do all the components
+      --filter=SELECTOR    Filter components based on selector
+                           (e.g. --filter=relase-process=docker)
       --version            Show version.
+      --conf=FILE          Configuration file location [default: builder.ini]
+      --with-versions      Print out all items of interest, with versions
+      --vs-branch=BRANCH   Discover changes made compared to BRANCH. If not set,
+                           comparison will be to latest staging branch for each
+                           component.
 
 ## Development
 

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,7 @@ dependencies:
     - cd component-builder && echo "0.0" > VERSION.txt && pip install -e .
     - pip freeze
     - compbuild discover  # just to output what will be built
+    - compbuild declare
     - compbuild build
   post:
     - pyenv local 2.7.10 3.5.2

--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -5,19 +5,19 @@ from docopt import docopt
 
 from . import build, discover, envs, github, release
 
-
 USAGE = """
 Intelligent builder for working with component-based repositories
 
 Usage:
   compbuild discover [--with-versions] [--vs-branch=BRANCH] {common}
+  compbuild declare [<component>...] {common}
   compbuild build [<component>...] {common}
-  compbuild env [<component>...] {common}
-  compbuild release [<component>...] {common}
   compbuild test [<component>...] {common}
-  compbuild tag [<component>...] {common}
   compbuild label <label> [<component>...] {common}
+  compbuild tag [<component>...] {common}
+  compbuild release [<component>...] {common}
   compbuild get <attr> [<component>...] {common}
+  compbuild env [<component>...] {common}
   compbuild -h | --help
   compbuild --version
 
@@ -67,6 +67,8 @@ def cli(out=sys.stdout):
             out.write(
                 tmpl.format(title=c.title, version=c.env['VERSION']) + '\n'
             )
+    elif arguments['declare']:
+        build.declare_components_usage(components)
     elif arguments['build']:
         b.pre('build', components)
         build.run('build', components)

--- a/component-builder/src/component_builder/build.py
+++ b/component-builder/src/component_builder/build.py
@@ -1,7 +1,7 @@
 import os.path
 
 from . import config, github
-from .utils import make, component_script
+from .utils import component_script, make
 
 
 class BuilderFailure(Exception):
@@ -31,8 +31,9 @@ def mark_commit_status(*args, **kwargs):
         return github.mark_status_for_component(*args, **kwargs)
 
 
-def declare_components_usage(titles):
+def declare_components_usage(components):
     if os.environ.get('INTERACT_WITH_GITHUB'):
+        titles = [c.title for c in components]
         prs = os.environ.get('PULL_REQUEST_NAMES', '')
         for pr_url in prs.split(','):
             if pr_url:
@@ -83,11 +84,8 @@ class Builder(object):
 def run(mode, components, status_callback=None, optional=False):
     errors = []
 
-    titles = []
     for comp in components:
-        titles.append(comp.title)
         mark_commit_status(mode, comp.title, 'pending')
-    declare_components_usage(titles)
 
     for comp in components:
         comp_name = comp.title

--- a/component-builder/tests/test_cli.py
+++ b/component-builder/tests/test_cli.py
@@ -1,7 +1,7 @@
-from io import StringIO
 import os
-from os.path import abspath, dirname, join
 import unittest
+from io import StringIO
+from os.path import abspath, dirname, join
 
 from mock import patch
 
@@ -183,3 +183,33 @@ class TestCli(unittest.TestCase):
             s.getvalue(),
             'dummy-app:app\n'
         )
+
+
+class TestCliDeclare(unittest.TestCase):
+
+    @patch('component_builder.build.os.environ', {
+        'BUILD_IDENTIFIER': '1',
+        'INTERACT_WITH_GITHUB': 'anything',
+        'PULL_REQUEST_NAMES': 'http://github.com/ployst/ployst/pulls/1',
+    })
+    @patch('sys.argv', ['compbuild', 'declare',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    @patch('component_builder.build.github.add_pr_components_labels')
+    def test_declare_calls_add_pr_components_labels_correctly(self, add_pr):
+        s = StringIO()
+        cli(out=s)
+
+        add_pr.assert_called_once_with(
+            'http://github.com/ployst/ployst/pulls/1',
+            ['dummy-app', 'dummy-integration', 'dummy-island-service']
+        )
+
+    @patch('component_builder.build.os.environ', {'BUILD_IDENTIFIER': '1'})
+    @patch('sys.argv', ['compbuild', 'declare',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    @patch('component_builder.build.github.add_pr_components_labels')
+    def test_declare_does_not_call_add_pr_components_labels(self, add_pr):
+        s = StringIO()
+        cli(out=s)
+
+        add_pr.assert_not_called()


### PR DESCRIPTION
When using a more fine grained flow with `component-builder`, i.e. 
```
for each component in compbuild discover:
    compbuild build component
    compbuild test component
    ...
```

... then we cannot remove old labels (changes in https://github.com/ployst/component-builder/pull/26 and https://github.com/ployst/component-builder/pull/29). Thus we need a separate command `declare` that can declare the usage of components on PRs via labels.

We also introduce the old way of declaring usage. That is, on build time we check if we need to add the component label to the PRs.

See [discussion](https://github.com/ployst/component-builder/pull/29#issuecomment-274031807)