### PR TITLE
Add downstream component to component's ini dict

### DIFF
--- a/component-builder/src/component_builder/config.py
+++ b/component-builder/src/component_builder/config.py
@@ -40,6 +40,11 @@ def read_configuration(builder_ini_file, root='.'):
             c = Component(**kwargs)
             component_config[c.title] = c
 
+    for component in component_config.values():
+        downstream_titles = [
+            comp.title for comp in component.get_downstream_builds()]
+        component.ini['downstream'] = ','.join(downstream_titles)
+
     return builder_config, component_config
 
 

--- a/component-builder/tests/test_component.py
+++ b/component-builder/tests/test_component.py
@@ -102,3 +102,36 @@ class TestDependencies(unittest.TestCase):
             sorted([d.title for d in upstream]),
             ['service-A', 'ui']
         )
+
+
+class TestDownstreamLabel(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        s = StringIO(dedent(
+            u"""
+            [ui]
+            path=ui
+
+            [service-A]
+            path=service-a
+
+            [integration]
+            path=integration
+            upstream=service-A,ui
+
+            [super-integration]
+            path=super-integration
+            upstream=integration
+            """))
+        cls.components = read_component_configuration(s)
+
+    def test_upstream_components_have_their_downstream_components(self):
+        self.assertEqual(
+            self.components['ui'].ini['downstream'],
+            'integration,super-integration')
+
+    def test_downstream_components_dont_have_downstream_components(self):
+        self.assertEqual(
+            self.components['super-integration'].ini['downstream'],
+            '')


### PR DESCRIPTION
Given a component:
```
  [componentA]
  ...
  upstream=componentB
```

enables the following usage:
```
  $ compbuild discover --filter downstream=componentA
  componentB
```