### PR TITLE
fix get_changed: two commands now

### DIFF
--- a/component-builder/src/component_builder/discover.py
+++ b/component-builder/src/component_builder/discover.py
@@ -7,10 +7,16 @@ def get_changed(candidates, branch=None):
 
     def is_changed(candidate):
         name = branch or candidate.branch_name('stable')
-        cmd = ('git diff --shortstat origin/{branch} '
-               '-- {0} || echo "1"'.format(candidate.path, branch=name))
-        b = bash(cmd)
-        return b.value().strip() != ''
+        git_differs = [
+            'git diff --shortstat origin/{branch}..'.format(branch=name),
+            'git diff HEAD'
+        ]
+        for differ in git_differs:
+            cmd = ("{0} -- {1} || echo '1'".format(differ, candidate.path))
+            b = bash(cmd)
+            if b.value().strip() != '':
+                return True
+        return False
     return filter(is_changed, candidates)
 
 


### PR DESCRIPTION
This fixes the issue with the git comparisons. 

`git diff origin/master..` will give us the things added in current branch (http://stackoverflow.com/a/24186641/1551613)

Unfortunately doesn't seem to be possible to also include unstaged/committed changes in that one.

`git diff HEAD` will give us both staged and unstaged changes that are yet to be committed

A fix for https://github.com/ployst/component-builder/pull/21#discussion_r97352853
