### PR TITLE
Add exclude-downstream flag

### DIFF
--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -9,7 +9,7 @@ USAGE = """
 Intelligent builder for working with component-based repositories
 
 Usage:
-  compbuild discover [--with-versions] [--vs-branch=BRANCH] {common}
+  compbuild discover [--with-versions] {common}
   compbuild declare [<component>...] {common}
   compbuild build [<component>...] {common}
   compbuild test [<component>...] {common}
@@ -32,9 +32,13 @@ Options:
   --vs-branch=BRANCH   Discover changes made compared to BRANCH. If not set,
                        comparison will be to latest staging branch for each
                        component.
+  --exclude-downstream  Only include directly changed things, not things that
+                        declare them as upstreams.
+
 
 """.format(
-    common='[--all] [--filter=SELECTOR ...] [--conf=FILE]'
+    common=('[--vs-branch=BRANCH] [--all] [--exclude-downstream] '
+            '[--filter=SELECTOR ...] [--conf=FILE]')
 )
 
 
@@ -56,6 +60,7 @@ def cli(out=sys.stdout):
         arguments['--all'],
         compare_branch=arguments['--vs-branch'],
         selectors=selectors,
+        include_downstream=not arguments['--exclude-downstream']
     )
     envs.set_envs(components)
 

--- a/component-builder/src/component_builder/component.py
+++ b/component-builder/src/component_builder/component.py
@@ -81,11 +81,13 @@ class Tree(object):
         return branches[0]
 
     @classmethod
-    def ordered(cls, root_candidates):
+    def ordered(cls, root_candidates, include_downstream=True):
         branches = []
 
         for c in root_candidates:
-            branch = [c] + [c for c in c.get_downstream_builds()]
+            branch = [c]
+            if include_downstream:
+                branch += [c for c in c.get_downstream_builds()]
             branches.append(branch)
 
         return cls.merge_branches(*branches)

--- a/component-builder/src/component_builder/discover.py
+++ b/component-builder/src/component_builder/discover.py
@@ -42,7 +42,7 @@ def filter_by(selectors, components):
 
 
 def run(components, component_names=None, get_all=False, compare_branch=None,
-        selectors=None):
+        selectors=None, include_downstream=True):
     "Get paths and titles of changed components"
     if component_names and get_all:
         print("Asked for specific components and get all. "
@@ -53,7 +53,8 @@ def run(components, component_names=None, get_all=False, compare_branch=None,
         candidates = components.values()
         if not get_all:
             candidates = get_changed(candidates, compare_branch)
-        candidates = Tree.ordered(candidates)
+
+        candidates = Tree.ordered(candidates, include_downstream)
 
     if selectors:
         candidates = filter_by(selectors, candidates)


### PR DESCRIPTION
This is useful especially with `declare` as you often don't want to declare to github that eg integration tests are "included" in a PR that don't directly touch integration tests.