### PR TITLE
Fix bug in downstream filtering

### DIFF
--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -97,10 +97,13 @@ def cli(out=sys.stdout):
     elif arguments['get']:
         tmpl = u"{title}:{attr}"
         for c in components:
+            value = c.ini.get(arguments['<attr>'], "")
+            if isinstance(value, list):
+                value = ','.join(value)
             out.write(
                 tmpl.format(
                     title=c.title,
-                    attr=c.ini.get(arguments['<attr>'], "")) + '\n'
+                    attr=value) + '\n'
             )
 
 

--- a/component-builder/src/component_builder/config.py
+++ b/component-builder/src/component_builder/config.py
@@ -43,7 +43,7 @@ def read_configuration(builder_ini_file, root='.'):
     for component in component_config.values():
         downstream_titles = [
             comp.title for comp in component.get_downstream_builds()]
-        component.ini['downstream'] = ','.join(downstream_titles)
+        component.ini['downstream'] = downstream_titles
 
     return builder_config, component_config
 

--- a/component-builder/src/component_builder/discover.py
+++ b/component-builder/src/component_builder/discover.py
@@ -30,10 +30,18 @@ def filter_by(selectors, components):
             exclude = True
 
         key, value = selector.split(sep)
+
+        component_value = component.ini.get(key)
         if exclude:
-            return component.ini.get(key) != value
+            if isinstance(component_value, list):
+                return value not in component_value
+            else:
+                return component.ini.get(key) != value
         else:
-            return component.ini.get(key) == value
+            if isinstance(component_value, list):
+                return value in component_value
+            else:
+                return component.ini.get(key) == value
 
     for selector in selectors:
         components = filter(partial(matches_selector, selector), components)

--- a/component-builder/src/component_builder/envs.py
+++ b/component-builder/src/component_builder/envs.py
@@ -35,7 +35,8 @@ def get_version(component):
     b = make(
         component.path,
         'version',
-        envs='BUILD_IDENTIFIER={0}'.format(os.environ.get('BUILD_IDENTIFIER', 'test')),
+        envs='BUILD_IDENTIFIER={0}'.format(
+            os.environ.get('BUILD_IDENTIFIER', 'test')),
         options='--silent',
     )
     if b.code != 0:

--- a/component-builder/tests/test_cli.py
+++ b/component-builder/tests/test_cli.py
@@ -198,19 +198,6 @@ class TestCli(unittest.TestCase):
             'dummy-island-service\n'
         )
 
-    @patch('sys.argv', ['compbuild', 'get', 'label', '--all',
-                        '--filter=release-process=docker',
-                        '--filter=label=app',
-                        '--conf={0}'.format(TEST_BUILDER_CONF)])
-    def test_get_ini_value(self):
-        s = StringIO()
-        cli(out=s)
-
-        self.assertEqual(
-            s.getvalue(),
-            'dummy-app:app\n'
-        )
-
 
 class TestCliDeclare(unittest.TestCase):
 
@@ -264,4 +251,32 @@ class TestCliDeclare(unittest.TestCase):
         add_pr.assert_called_once_with(
             'http://github.com/ployst/ployst/pulls/1',
             ['dummy-app']
+        )
+
+
+class TestGetIniValues(unittest.TestCase):
+
+    @patch('sys.argv', ['compbuild', 'get', 'downstream', 'dummy-foo',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    @patch('component_builder.build.github.add_pr_components_labels')
+    def test_get_downstream_components(self, add_pr):
+        s = StringIO()
+        cli(out=s)
+
+        self.assertEqual(
+            s.getvalue(),
+            'dummy-foo:dummy-foo-integration-builder,dummy-integration\n'
+        )
+
+    @patch('sys.argv', ['compbuild', 'get', 'label', '--all',
+                        '--filter=release-process=docker',
+                        '--filter=label=app',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    def test_get_ini_value(self):
+        s = StringIO()
+        cli(out=s)
+
+        self.assertEqual(
+            s.getvalue(),
+            'dummy-app:app\n'
         )

--- a/component-builder/tests/test_cli.py
+++ b/component-builder/tests/test_cli.py
@@ -138,6 +138,22 @@ class TestCli(unittest.TestCase):
             ])
         )
 
+    @patch('sys.argv', ['compbuild', 'discover',
+                        '--all',
+                        '--filter=downstream=dummy-foo-integration-builder',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    def test_discover_filter_by_downstream(self):
+        s = StringIO()
+        cli(out=s)
+
+        self.assertEqual(
+            s.getvalue(),
+            '\n'.join([
+                'dummy-foo',
+                ''
+            ])
+        )
+
     @patch('sys.argv', ['compbuild', 'build', '--all',
                         '--conf={0}'.format(TEST_BUILDER_CONF)])
     def test_custom_commands(self):
@@ -155,7 +171,9 @@ class TestCli(unittest.TestCase):
             "bar dummy-foo-integration-builder\nbar dummy-integration\n"
         )
 
-    @patch('sys.argv', ['compbuild', 'discover', '--vs-branch=master',
+    @patch('sys.argv', ['compbuild', 'discover',
+                        '--filter=path=dummy-island-service',
+                        '--vs-branch=master',
                         '--conf={0}'.format(TEST_BUILDER_CONF)])
     def test_discover_only_finds_changes(self):
         s = StringIO()
@@ -166,7 +184,9 @@ class TestCli(unittest.TestCase):
             ''
         )
 
-    @patch('sys.argv', ['compbuild', 'discover', '--vs-branch=master',
+    @patch('sys.argv', ['compbuild', 'discover',
+                        '--filter=path=dummy-island-service',
+                        '--vs-branch=master',
                         '--conf={0}'.format(TEST_BUILDER_CONF)])
     def test_discover_local_uncommitted_changes_count(self):
         setup_changed_file(self, 'dummy-island-service')
@@ -203,7 +223,8 @@ class TestCliDeclare(unittest.TestCase):
         'INTERACT_WITH_GITHUB': 'anything',
         'PULL_REQUEST_NAMES': 'http://github.com/ployst/ployst/pulls/1',
     })
-    @patch('sys.argv', ['compbuild', 'declare',
+    @patch('sys.argv', ['compbuild', 'declare', 'dummy-app',
+                        'dummy-integration',
                         '--vs-branch=master',
                         '--conf={0}'.format(TEST_BUILDER_CONF)])
     @patch('component_builder.build.github.add_pr_components_labels')

--- a/component-builder/tests/test_component.py
+++ b/component-builder/tests/test_component.py
@@ -129,9 +129,9 @@ class TestDownstreamLabel(unittest.TestCase):
     def test_upstream_components_have_their_downstream_components(self):
         self.assertEqual(
             self.components['ui'].ini['downstream'],
-            'integration,super-integration')
+            ['integration', 'super-integration'])
 
     def test_downstream_components_dont_have_downstream_components(self):
         self.assertEqual(
             self.components['super-integration'].ini['downstream'],
-            '')
+            [])

--- a/component-builder/tests/test_envs.py
+++ b/component-builder/tests/test_envs.py
@@ -41,7 +41,8 @@ class TestSetEnvs(unittest.TestCase):
              'DOCKER_TAG=2.0.0.1',
              'DUMMY_APP_DOCKER_IMAGE=dummy-app:5.4.0.1',
              'DUMMY_FOO_DOCKER_IMAGE=dummy-foo:1.0.0.1',
-             'DUMMY_FOO_INTEGRATION_BUILDER_DOCKER_IMAGE=dummy-foo-integration-builder:2.0.0.1',
+             'DUMMY_FOO_INTEGRATION_BUILDER_DOCKER_IMAGE='
+                'dummy-foo-integration-builder:2.0.0.1',
              'NAME=dummy-integration',
              'REPORT_LOCATION=/reports/dummy-integration',
              'VERSION=2.0.0.1']


### PR DESCRIPTION
Found an issue recently where downstream based filtering wasn't working when we have a component that has multiple downstreams (you had to know the full string to filter on)

Note that due to comparisons to master, I first pushed this commit to master:
https://github.com/ployst/component-builder/commit/ec9b57578d57161a02714e89ca9694df18e2af07

(in order to not have tests failing here due to the new components looking like they had changed)