### PR TITLE
Add custom per-component command support

### DIFF
--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -18,6 +18,7 @@ Usage:
   compbuild release [<component>...] {common}
   compbuild get <attr> [<component>...] {common}
   compbuild env [<component>...] {common}
+  compbuild <action> [<component>...] {common}
   compbuild -h | --help
   compbuild --version
 
@@ -105,6 +106,13 @@ def cli(out=sys.stdout):
                     title=c.title,
                     attr=value) + '\n'
             )
+    elif arguments['<action>']:
+        b.pre(arguments['<action>'], components)
+        for bash_out in build.run(arguments['<action>'], components,
+                                  make_options="-s"):
+            print(bash_out)
+            out.write(u'{0}'.format(bash_out.value()))
+        b.post(arguments['<action>'], components)
 
 
 if __name__ == '__main__':

--- a/component-builder/src/component_builder/build.py
+++ b/component-builder/src/component_builder/build.py
@@ -81,7 +81,8 @@ class Builder(object):
         return self.hook('post-{}'.format(stage), components)
 
 
-def run(mode, components, status_callback=None, optional=False):
+def run(mode, components, status_callback=None, optional=False,
+        make_options=""):
     errors = []
 
     for comp in components:
@@ -97,7 +98,9 @@ def run(mode, components, status_callback=None, optional=False):
         success = True
         try:
             b = make(
-                comp.path, mode, envs=comp.env_string, output_console=True)
+                comp.path, mode, envs=comp.env_string, options=make_options,
+                output_console=True)
+
             if b.code != 0:
                 success = False
         except Exception:
@@ -105,6 +108,7 @@ def run(mode, components, status_callback=None, optional=False):
 
         if success:
             mark_commit_status(mode, comp_name, 'success')
+            yield b
         else:
             errors.append(comp_name)
             mark_commit_status(mode, comp_name, 'error')

--- a/component-builder/tests/dummy-single-repo/dummy-foo/Makefile
+++ b/component-builder/tests/dummy-single-repo/dummy-foo/Makefile
@@ -1,5 +1,8 @@
 build:
 	echo "Building dummy foo"
 
+foo:
+	bash ../script-foo.sh
+
 version:
 	echo "1.0.${BUILD_IDENTIFIER}"

--- a/component-builder/tests/test_cli.py
+++ b/component-builder/tests/test_cli.py
@@ -156,7 +156,7 @@ class TestCli(unittest.TestCase):
 
     @patch('sys.argv', ['compbuild', 'build', '--all',
                         '--conf={0}'.format(TEST_BUILDER_CONF)])
-    def test_custom_commands(self):
+    def test_pre_step_scripts(self):
         script_out = '/tmp/foo-out'
         try:
             os.remove(script_out)
@@ -196,6 +196,22 @@ class TestCli(unittest.TestCase):
         self.assertEqual(
             s.getvalue(),
             'dummy-island-service\n'
+        )
+
+    @patch('sys.argv', ['compbuild', 'foo', 'dummy-foo',
+                        '--conf={0}'.format(TEST_BUILDER_CONF)])
+    def test_individual_custom_commands(self):
+        script_out = '/tmp/foo-out'
+        try:
+            os.remove(script_out)
+        except OSError:
+            pass
+
+        cli()
+
+        self.assertEqual(
+            open(script_out).read(),
+            "bar dummy-foo\n"
         )
 
 


### PR DESCRIPTION
This allows the user to greatly extend the component builder to be much more flexible:

For example:
```
$ compbuild get-deploy-commands chart-deployer
"CHART=ops deploy"
"CHART=ops verify"
"CHART=azs deploy"
"CHART=azs verify"
"cross-test"
```

And have the jenkins file ask what commands to run before calling back.

This means that the logic for things can live outside of the jenkinsfile, whilst still providing a way for the jenkinsfile to display the progress of the build.