### PR TITLE
Handle circular references in builder.ini

### DIFF
--- a/component-builder/src/component_builder/component.py
+++ b/component-builder/src/component_builder/component.py
@@ -30,20 +30,32 @@ class Component(object):
     def env_string(self):
         return convert_dict_to_env_string(self.env)
 
-    def get_upstream_builds(self):
+    def get_upstream_builds(self, exclude=None):
         upstream = []
+        if not exclude:
+            exclude = []
         for ds in self.upstream:
             component = self.all[ds]
+            if component in exclude or component == self:
+                continue
             upstream.append(component)
-            upstream.extend(component.get_upstream_builds())
+            exclude = upstream + [self]
+            upstream.extend(component.get_upstream_builds(exclude=exclude))
         return upstream
 
-    def get_downstream_builds(self):
+    def get_downstream_builds(self, exclude=None):
         downstream = []
+        if not exclude:
+            exclude = []
         for component in self.all.values():
+            if component in exclude or component == self:
+                continue
             if self.title in component.upstream:
                 downstream.append(component)
-                downstream.extend(component.get_downstream_builds())
+                exclude = downstream + [self]
+                downstream.extend(
+                    component.get_downstream_builds(exclude=exclude)
+                )
         return downstream
 
     def __repr__(self):

--- a/component-builder/src/component_builder/component.py
+++ b/component-builder/src/component_builder/component.py
@@ -36,10 +36,10 @@ class Component(object):
             exclude = []
         for ds in self.upstream:
             component = self.all[ds]
-            if component in exclude or component == self:
+            if component in exclude or component.title == self.title:
                 continue
             upstream.append(component)
-            exclude = upstream + [self]
+            exclude = exclude + upstream + [self]
             upstream.extend(component.get_upstream_builds(exclude=exclude))
         return upstream
 
@@ -48,14 +48,15 @@ class Component(object):
         if not exclude:
             exclude = []
         for component in self.all.values():
-            if component in exclude or component == self:
+            if component in exclude or component.title == self.title:
                 continue
             if self.title in component.upstream:
                 downstream.append(component)
-                exclude = downstream + [self]
+                exclude = exclude + downstream + [self]
                 downstream.extend(
                     component.get_downstream_builds(exclude=exclude)
                 )
+
         return downstream
 
     def __repr__(self):

--- a/component-builder/tests/test_component.py
+++ b/component-builder/tests/test_component.py
@@ -124,13 +124,16 @@ class TestDownstreamLabel(unittest.TestCase):
             path=super-integration
             upstream=integration
 
+            [other-thing]
+            path=other-thing
+
             [circular-a]
             path=a
             upstream=circular-b
 
             [circular-b]
             path=b
-            upstream=circular-a
+            upstream=other-thing,circular-a
             """))
         cls.components = read_component_configuration(s)
 

--- a/component-builder/tests/test_component.py
+++ b/component-builder/tests/test_component.py
@@ -123,6 +123,14 @@ class TestDownstreamLabel(unittest.TestCase):
             [super-integration]
             path=super-integration
             upstream=integration
+
+            [circular-a]
+            path=a
+            upstream=circular-b
+
+            [circular-b]
+            path=b
+            upstream=circular-a
             """))
         cls.components = read_component_configuration(s)
 
@@ -135,3 +143,13 @@ class TestDownstreamLabel(unittest.TestCase):
         self.assertEqual(
             self.components['super-integration'].ini['downstream'],
             [])
+
+    def test_handles_circular_references(self):
+        self.assertEqual(
+            self.components['circular-b'].ini['downstream'],
+            ['circular-a']
+        )
+        self.assertEqual(
+            self.components['circular-a'].ini['downstream'],
+            ['circular-b']
+        )


### PR DESCRIPTION
If one wants to have 2 things build when either of them change then circular references are important.

This fixes a "max-recursion" bug.