### PR TITLE
Add support for outputting make file contents to a file

### DIFF
--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -35,11 +35,12 @@ Options:
                        component.
   --exclude-downstream  Only include directly changed things, not things that
                         declare them as upstreams.
+  --out=FILE           Write make command output to FILE rather than stdout.
 
 
 """.format(
     common=('[--vs-branch=BRANCH] [--all] [--exclude-downstream] '
-            '[--filter=SELECTOR ...] [--conf=FILE]')
+            '[--filter=SELECTOR ...] [--conf=FILE] [--out=FILE]')
 )
 
 
@@ -48,6 +49,9 @@ def cli(out=sys.stdout):
 
     b = build.Builder(arguments['--conf'])
     b.configure()
+    # out = sys.stdout
+    if arguments['--out']:
+        out = open(arguments['--out'], 'w')
 
     selectors = set()
     filters = arguments['--filter']
@@ -108,12 +112,13 @@ def cli(out=sys.stdout):
             )
     elif arguments['<action>']:
         b.pre(arguments['<action>'], components)
-        for bash_out in build.run(arguments['<action>'], components,
-                                  make_options="-s"):
-            print(bash_out)
-            out.write(u'{0}'.format(bash_out.value()))
+        build.run(arguments['<action>'], components, make_options="-s",
+                  make_output={'stdout': out, 'stderr': sys.stderr})
         b.post(arguments['<action>'], components)
 
+    if arguments['--out']:
+        print "CLOSING"
+        out.close()
 
 if __name__ == '__main__':
     cli()

--- a/component-builder/src/component_builder/__main__.py
+++ b/component-builder/src/component_builder/__main__.py
@@ -44,12 +44,12 @@ Options:
 )
 
 
-def cli(out=sys.stdout):
+def cli(out=sys.stdout, err=sys.stderr):
     arguments = docopt(USAGE, version='1.0')
 
     b = build.Builder(arguments['--conf'])
     b.configure()
-    # out = sys.stdout
+
     if arguments['--out']:
         out = open(arguments['--out'], 'w')
 
@@ -113,12 +113,12 @@ def cli(out=sys.stdout):
     elif arguments['<action>']:
         b.pre(arguments['<action>'], components)
         build.run(arguments['<action>'], components, make_options="-s",
-                  make_output={'stdout': out, 'stderr': sys.stderr})
+                  make_output={'stdout': out, 'stderr': err})
         b.post(arguments['<action>'], components)
 
     if arguments['--out']:
-        print "CLOSING"
         out.close()
+
 
 if __name__ == '__main__':
     cli()

--- a/component-builder/src/component_builder/build.py
+++ b/component-builder/src/component_builder/build.py
@@ -1,4 +1,5 @@
 import os.path
+import sys
 
 from . import config, github
 from .utils import component_script, make
@@ -67,7 +68,7 @@ class Builder(object):
                     comp.path,
                     script_path,
                     envs=comp.env_string,
-                    output_console=False
+                    # output_console=False
                 )
                 if b.code != 0:
                     errors.append(comp.title)
@@ -82,7 +83,7 @@ class Builder(object):
 
 
 def run(mode, components, status_callback=None, optional=False,
-        make_options=""):
+        make_options="", make_output=None):
     errors = []
     bashes = []
     for comp in components:
@@ -96,11 +97,14 @@ def run(mode, components, status_callback=None, optional=False,
             print("Not available")
             continue
         success = True
+        if not make_output:
+            # Ignore if running --xunit tests (identified by use of Tee)
+            if sys.stdout.__class__.__name__ != 'Tee':
+                make_output = {'stdout': sys.stdout, 'stderr': sys.stderr}
         try:
             b = make(
                 comp.path, mode, envs=comp.env_string, options=make_options,
-                output_console=True)
-
+                output=make_output)
             if b.code != 0:
                 success = False
             bashes.append(b)

--- a/component-builder/src/component_builder/discover.py
+++ b/component-builder/src/component_builder/discover.py
@@ -55,6 +55,7 @@ def run(components, component_names=None, get_all=False, compare_branch=None,
     if component_names and get_all:
         print("Asked for specific components and get all. "
               "Assuming specific components...")
+
     if component_names:
         candidates = [components[x] for x in component_names]
     else:

--- a/component-builder/src/component_builder/utils.py
+++ b/component-builder/src/component_builder/utils.py
@@ -1,5 +1,3 @@
-import sys
-
 from bash import bash as bash_graceful
 
 

--- a/component-builder/src/component_builder/utils.py
+++ b/component-builder/src/component_builder/utils.py
@@ -20,21 +20,19 @@ def convert_dict_to_env_string(envdict):
     return env_string
 
 
-def make(path, cmd, envs="", options="", output_console=False):
+def make(path, cmd, envs="", options="", output=None):
     cmd = 'make {0} {1}'.format(options, cmd)
     return component_script(
-        path=path, script=cmd, envs=envs, output_console=output_console
+        path=path, script=cmd, envs=envs, output=output
     )
 
 
-def component_script(path, script, envs="", output_console=False):
+def component_script(path, script, envs="", output=None):
     full_cmd = 'cd {path} && {envs} {0}'.format(
         script, path=path, envs=envs)
     bashkw = {}
 
-    if output_console:
-        # Ignore if running --xunit tests (identified by use of Tee)
-        if sys.stdout.__class__.__name__ != 'Tee':
-            bashkw = {'stdout': sys.stdout, 'stderr': sys.stderr}
+    if output:
+        bashkw = output
 
     return bash(full_cmd, **bashkw)


### PR DESCRIPTION
Adds redirecting makefile output to a particular file given at the command line.

This is useful if you want to ask components a question whose answer you want to parse without eg the title banner of the command run being included in the answer