### PR TITLE
Improve output so that it's easier to locate issues

### DIFF
--- a/component-builder/src/component_builder/build.py
+++ b/component-builder/src/component_builder/build.py
@@ -61,16 +61,17 @@ class Builder(object):
             errors = []
             script_path = os.path.abspath(os.path.join(self.path, script_name))
             for comp in components:
-                b = component_script(
-                    comp.path,
-                    script_path,
-                    envs=comp.env_string,
-                    output=output,
-                )
-                if b.code != 0:
-                    errors.append(comp.title)
+                try:
+                    component_script(
+                        comp.path,
+                        script_path,
+                        envs=comp.env_string,
+                        output=output,
+                    )
+                except exceptions.SubscriptException as e:
+                    errors.append((comp.title, e.output))
             if errors:
-                raise BuilderFailure(script_name, errors)
+                raise exceptions.BuilderFailure(script_name, errors)
 
     def pre(self, stage, components):
         return self.hook('pre-{}'.format(stage), components)

--- a/component-builder/src/component_builder/exceptions.py
+++ b/component-builder/src/component_builder/exceptions.py
@@ -1,0 +1,25 @@
+class SubscriptException(Exception):
+    def __init__(self, bash, cmd, output):
+        self.bash = bash
+        self.cmd = cmd
+        self.output = output
+
+    def __str__(self):
+        return 'Error running command {0}:\n - {1}'.format(
+            self.cmd, self.output)
+
+
+class BuilderFailure(Exception):
+    def __init__(self, mode, errors):
+        super(BuilderFailure, self).__init__()
+        self.error_components = errors
+        self.mode = mode
+
+    def __str__(self):
+
+        comps = ", ".join([': '.join(ec) for ec in self.error_components])
+
+        return ('{0} components failed to {1}: \n'
+                ' - {2}'.format(
+            len(self.error_components), self.mode, comps)
+        )

--- a/component-builder/src/component_builder/exceptions.py
+++ b/component-builder/src/component_builder/exceptions.py
@@ -19,7 +19,6 @@ class BuilderFailure(Exception):
 
         comps = ", ".join([': '.join(ec) for ec in self.error_components])
 
-        return ('{0} components failed to {1}: \n'
-                ' - {2}'.format(
+        return ('{0} components failed to {1}: \n - {2}'.format(
             len(self.error_components), self.mode, comps)
         )

--- a/component-builder/src/component_builder/utils.py
+++ b/component-builder/src/component_builder/utils.py
@@ -1,5 +1,4 @@
 import subprocess
-import sys
 
 from bash import bash as bash_graceful
 
@@ -22,32 +21,31 @@ class bash(bash_graceful):
         while True:
 
             outline = ret.p.stdout.readline()
-            outline = outline.decode('utf_8')
+            outline = outline
 
             if not outline:
                 break
 
             output_out.append(outline)
             if stdout:
-                stdout.write(outline)
+                stdout.write(outline.decode('utf_8'))
 
-        self.stdout = ''.join(output_out)
-        self.stderr = ret.p.stderr.read().decode('utf_8')
+        self.stdout = b''.join(output_out)
+        self.stderr = ret.p.stderr.read()
         if stderr:
-            stderr.write(self.stderr)
+            stderr.write(self.stderr.decode('utf_8'))
         self.code = ret.p.wait()
 
-        if ret.code != 0:
+        if self.code != 0:
             raise exceptions.SubscriptException(
-                ret, cmd, ''.join(ret.stderr))
+                self, cmd, ''.join(self.stderr))
 
-        return ret
+        return self
 
     def bash(self, cmd, *args, **kwargs):
         return self.bash_with_captured_and_potentially_exposed_output(
             cmd, *args, **kwargs
         )
-
 
 
 def convert_dict_to_env_string(envdict):

--- a/component-builder/tox.ini
+++ b/component-builder/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py35
 
 [testenv]
 passenv = *


### PR DESCRIPTION
This improves the output I think. No longer will we get long stacktraces that are essentially saying "compbuild raised an exception because some lower thing returned !0"

Instead, we'll see a test error, that can be easily searched for with "FAILURE" at the beginning

The reason that there's so much jiggery pokery going on with stdout and stderr is because I'd like to have the following behaviour:
 - Be able to run a long running script, via compbuild, and see output as it goes (eg docker build)
 - Be able to also capture the output for use later on

If this all works fine with Azazo's repo, I can see us wanting to do things like:
 - auto export stdout and stderr to some file for a command run on failure so that jenkins debugging is easier.