### PR TITLE
Show stdout live, just keep stderr for later

### DIFF
--- a/component-builder/src/component_builder/utils.py
+++ b/component-builder/src/component_builder/utils.py
@@ -9,15 +9,11 @@ from . import exceptions
 class bash(bash_graceful):
 
     def bash(self, cmd, *args, **kwargs):
-        stdout = kwargs.get('stdout', None)
         stderr = kwargs.get('stderr', None)
-        kwargs['stdout'] = subprocess.PIPE
         kwargs['stderr'] = subprocess.PIPE
 
         ret = super(bash, self).bash(cmd, *args, **kwargs)
 
-        if stdout and stdout != sys.stdout:
-            stdout.write(ret.stdout.decode('utf_8'))
         if stderr and stderr != sys.stderr:
             stderr.write(ret.stderr.decode('utf_8'))
 


### PR DESCRIPTION
this is closer now to what we want. 

It's not perfect, because I really want stderr both during and after, but I think this is the best compromise given that it appears you can't pass non FDs to popen.

A longer term fix would probably be to stream to a file and have a thread stream that file to stdout, but that's for another day.