### PR TITLE
Fix labelling as stable

### DIFF
--- a/component-builder/src/component_builder/component.py
+++ b/component-builder/src/component_builder/component.py
@@ -24,7 +24,7 @@ class Component(object):
         self.ini = ini
 
     def branch_name(self, label='stable'):
-        return "origin/{0}-{1}".format(label, self.title)
+        return "{0}-{1}".format(label, self.title)
 
     @property
     def env_string(self):

--- a/component-builder/src/component_builder/discover.py
+++ b/component-builder/src/component_builder/discover.py
@@ -6,7 +6,7 @@ from .utils import bash
 def get_changed(candidates, sha=None):
 
     def is_changed(candidate):
-        name = sha or candidate.branch_name('stable')
+        name = sha or 'origin/' + candidate.branch_name('stable')
         git_differs = [
             'git diff --shortstat {sha}...'.format(sha=name),
             'git diff HEAD'


### PR DESCRIPTION
Labelling as stable was broken since https://github.com/ployst/component-builder/pull/48 because we would create branches called `origin/stable-component` rather than just `stable-component`.