### PR TITLE
update_branch method doesn't work with latest github3 when branch is missing

### DIFF
--- a/component-builder/setup.py
+++ b/component-builder/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         'bash>=0.5',
         'docopt',
-        'github3.py>=1.0.0a3',
+        'github3.py>=1.0.0',
         'pytz>=2015.4'
     ],
     scripts=[

--- a/component-builder/setup.py
+++ b/component-builder/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         'bash>=0.5',
         'docopt',
-        'github3.py>=1.0.0',
+        'github3.py~=1.0.0',
         'pytz>=2015.4'
     ],
     scripts=[

--- a/component-builder/src/component_builder/github.py
+++ b/component-builder/src/component_builder/github.py
@@ -69,10 +69,10 @@ def update_branch(branch_name):
     sha = get_sha()
     repo = get_repo()
 
-    b = repo.ref('heads/{0}'.format(branch_name))
-    if b and not isinstance(b, github3.exceptions.UnprocessableResponseBody):
+    try:
+        b = repo.ref('heads/{0}'.format(branch_name))
         b.update(sha, force=True)
-    else:
+    except github3.exceptions.NotFoundError:
         repo.create_ref('refs/heads/{0}'.format(branch_name), sha)
 
 


### PR DESCRIPTION
With recent updates in (github3.py)phttps://github.com/sigmavirus24/github3.py] library it doesn't return `github3.exceptions.UnprocessableResponseBody` when ref doesn't exist but raises `github3.exceptions.NotFoundError` instead:
```
Traceback (most recent call last):
  File "tmp/.env/local/lib/python2.7/site-packages/component_builder/__main__.py", line 108, in cli
    github.update_branch(comp.branch_name(arguments['<label>']))
  File "tmp/.env/local/lib/python2.7/site-packages/component_builder/github.py", line 72, in update_branch
    b = repo.ref('heads/{0}'.format(branch_name))
  File "tmp/.env/local/lib/python2.7/site-packages/github3/repos/repo.py", line 2444, in ref
    json = self._json(self._get(url), 200)
  File "tmp/.env/local/lib/python2.7/site-packages/github3/models.py", line 156, in _json
    raise exceptions.error_for(response)
github3.exceptions.NotFoundError: 404 Not Found
```